### PR TITLE
fix folder deletion

### DIFF
--- a/STRUCTS/Folder.lua
+++ b/STRUCTS/Folder.lua
@@ -100,14 +100,30 @@ end
 function Folder.Delete(index)
 
     -- kill all child folders/windows
-    for i, item in ipairs(Data.window) do
-        if item.folder == index then
-            Options.DeleteWindow( i )
+    local delete = true
+    local startIndex = 1
+    while delete do 
+        delete = false
+        for i=startIndex,#Data.window do
+            if Data.window[i].folder == index then
+                delete = true
+                startIndex = i
+                Options.DeleteWindow( i )
+                break
+            end
         end
     end
-    for j, item in ipairs(Data.folder) do
-        if item.folder == index then
-            Options.DeleteFolder( j )
+    local delete = true
+    local startIndex = 1
+    while delete do 
+        delete = false
+        for i=startIndex,#Data.folder do
+            if Data.folder[i].folder == index then
+                delete = true
+                startIndex = i
+                Options.DeleteFolder( i )
+                break
+            end
         end
     end
 


### PR DESCRIPTION
When deleting folder, the tables were changed during the foreach loop with resulted in not proper execution and not deleting all the entries.
Steps to reproduce on clean install:

- create folder
- create timer window inside folder
- create another timer window inside folder (optionally repeat this step)
- delete folder
- create a new folder
- it will have one of the old timer windows already inside (potentially more than one)

Steps to crash the game:

- create first folder
- create second folder inside it
- create another folder in first folder (but not inside second one)
- delete first folder
- game stops responding 

Fix: combine while and numeric for to iterate over the table and delete all elements 